### PR TITLE
fix: etext escape

### DIFF
--- a/src/ast/tex_unicode.rs
+++ b/src/ast/tex_unicode.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, hash::BuildHasherDefault};
+use std::{collections::HashMap, hash::{BuildHasherDefault, Hash}};
 use lazy_static::lazy_static;
 use ahash::AHasher;
 use crate::config;
@@ -22,7 +22,7 @@ fn spilt_as_char(s: &str) -> Vec<char>{
             // 1. \n \t \r等转义字符 -> Escape
             // 2. \d{1~5} unicode码点 -> Unicode
             // 3. \" \\ 等引号内转义字符
-            // TODO: 可能会出现i+1越界的情况, 主要是\后面没有字符的情况, 实际上是非法的
+            // ! WARING: 可能会出现i+1越界的情况, 主要是\后面没有字符的情况, 实际上是非法的
             let next = s.chars().nth(i + 1).unwrap();
             if next.is_ascii_digit() {
                 let mut j = i + 1;
@@ -62,19 +62,20 @@ fn spilt_as_char(s: &str) -> Vec<char>{
 #[test]
 fn test_escapse_text(){
     let s = r#"@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_""#;
-    let res = escapse_text(s);
+    let res = escapse_text(s, true);
     println!("{:?}", res);
 }
+
 // 把文本中的\1234直接转为unicode
-pub fn escapse_text(s: &str) -> String{
+pub fn escapse_text(s: &str, escape: bool) -> String{
     let mut res = String::new();
     let chars = spilt_as_char(s);
     for c in chars {
-        if let Some(escaped) = escape_latex(c) {
-            if escaped == "\\ "{
-                res.push_str(" ");
+        if escape{
+            if let Some(escapse) = escape_latex(c) {
+                res.push_str(&escapse);
             }else{
-                res.push_str(&escaped);
+                res.push(c);
             }
         }else{
             res.push(c);

--- a/src/ast/tex_writer.rs
+++ b/src/ast/tex_writer.rs
@@ -1,4 +1,5 @@
 use core::panic;
+use std::ascii::escape_default;
 use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
@@ -267,6 +268,7 @@ pub fn write_tex_equation(exps: Vec<Exp>) -> Result<String, String>{
     twc.push_raw("\\]");
     Ok(twc.tex.clone())
 }
+
 pub fn write_tex_default(exps: Vec<Exp>) -> Result<String, String>{
     let mut twc = default_context();
     for exp in &exps {
@@ -274,6 +276,7 @@ pub fn write_tex_default(exps: Vec<Exp>) -> Result<String, String>{
     }
     Ok(twc.tex.clone())
 }
+
 #[test]
 fn test_write_tex_with_md(){
     let envs = HashMap::new();
@@ -325,12 +328,14 @@ fn test_write_tex_with_md(){
     let res = write_tex_with_md(exps, &envs).unwrap();
     println!("res: {:?}", res);
 }
+
 pub fn write_tex_with_md(exps: Vec<Exp>, envs: &HashMap<String, bool>) -> Result<String, String>{
     let mut twc = default_context();
+    twc.envs = envs.clone();
     if exps.len() == 1{
         return match exps[0] {
             Exp::EText(TextType::TextNormal, ref s) => {
-                twc.push_text(s);
+                twc.push_text(&escapse_text(s, true));
                 Ok(twc.tex.clone())
             },
             _ => {
@@ -352,7 +357,7 @@ pub fn write_tex_with_md(exps: Vec<Exp>, envs: &HashMap<String, bool>) -> Result
                     twc.push_raw("\\) ");
                     in_exp = false;
                 }
-                twc.push_text(s);
+                twc.push_text(&escapse_text(s, true));
             },
             _ => {
                 if !in_exp {
@@ -1162,7 +1167,7 @@ fn write_exp(c: &mut TexWriterContext, exp: &Exp) -> Result<(), String>{
                 return Ok(());
             }
             let (cmd, repeats) = shared::get_text_cmd(text_type);
-            let text = &escapse_text(str);
+            let text = &escapse_text(str, false);
 
             c.push_text(&format!("{}{}{}", cmd, text, "}".repeat(repeats as usize)));
         },


### PR DESCRIPTION
fix: etext esacpe

[EText TextNormal " XtoV_gain "]

true: -> \text{ XtoV_gain }
err:  -> \text{ XtoV\_gain }
